### PR TITLE
feat: SubscriptionUpdatedEvent'e workPackagesEnabled eklendi

### DIFF
--- a/dist/common/events/subscription-updated-event.d.ts
+++ b/dist/common/events/subscription-updated-event.d.ts
@@ -25,5 +25,6 @@ export interface SubscriptionUpdatedEvent {
         status: "active" | "trial" | "past_due" | "cancelled" | "expired";
         currentPeriodStart?: Date;
         currentPeriodEnd: Date;
+        workPackagesEnabled?: boolean;
     };
 }

--- a/src/common/events/subscription-updated-event.ts
+++ b/src/common/events/subscription-updated-event.ts
@@ -21,5 +21,6 @@ export interface SubscriptionUpdatedEvent {
         status: "active" | "trial" | "past_due" | "cancelled" | "expired";
         currentPeriodStart?: Date;
         currentPeriodEnd: Date;
+        workPackagesEnabled?: boolean;
     };
 }


### PR DESCRIPTION
## Özet
- `SubscriptionUpdatedEvent` interface'ine `workPackagesEnabled?: boolean` alanı eklendi
- Plan bazlı iş paketi erişim kontrolü için gerekli

## İlgili Issue
Closes #304 (ana repo)

---
*Bu PR `/work 304` komutu ile oluşturulmuştur.*