### PR TITLE
fix: common-client ana build'e dahil edildi

### DIFF
--- a/common-client.d.ts
+++ b/common-client.d.ts
@@ -1,1 +1,1 @@
-export * from './dist-client/common-client';
+export * from './dist/common-client';

--- a/common-client.js
+++ b/common-client.js
@@ -1,3 +1,3 @@
-// Proxy — webpack exports field resolve sorunu için
-// @xmoonx/moon-lib/common-client → dist-client/common-client.js
-module.exports = require('./dist-client/common-client');
+// Proxy — @xmoonx/moon-lib/common-client → dist/common-client.js
+// dist/ ana build'de her zaman oluşur (dist-client/ opsiyonel)
+module.exports = require('./dist/common-client');

--- a/dist/common-client.d.ts
+++ b/dist/common-client.d.ts
@@ -1,0 +1,52 @@
+/**
+ * common-client.ts — Frontend-safe entry point
+ *
+ * Bu dosya sadece client (Next.js) tarafından kullanılacak
+ * frontend-safe export'ları içerir. Backend-specific bağımlılıklar
+ * (Mongoose, NATS, Redis vb.) bu entry point'ten hariç tutulmuştur.
+ */
+export * from './common/types/address-type';
+export * from './common/types/attributes-type';
+export * from './common/types/common.types';
+export * from './common/types/credential-type';
+export * from './common/types/credential-group';
+export * from './common/types/currency-code';
+export * from './common/types/currency-symbol';
+export * from './common/types/entity.types';
+export * from './common/types/fix-status';
+export * from './common/types/integration-status';
+export * from './common/types/integration-type';
+export * from './common/types/integration-limits';
+export * from './common/types/number-comparisons-type';
+export * from './common/types/resourceName';
+export * from './common/types/sort-type';
+export * from './common/types/stock-action-type';
+export * from './common/types/unit-type';
+export * from './common/types/user-role';
+export * from './common/types/permission.types';
+export * from './common/types/integration-params';
+export * from './common/types/cron-defaults';
+export * from './common/events/types/order-status';
+export * from './common/events/types/order-status2';
+export * from './common/events/types/order-type';
+export * from './common/events/types/product-type';
+export * from './common/events/types/product-status';
+export * from './common/events/types/payment-type';
+export * from './common/events/types/return-status';
+export * from './common/events/types/invoice-status';
+export { Subjects } from './common/events/subjects';
+export * from './common/constants/cargo-label-support.constants';
+export * from './common/constants/integration-commands';
+export * from './common/interfaces/validator-func-params.interface';
+export * from './common/interfaces/integration-instance.interface';
+export * from './common/interfaces/product-integration-created.interface';
+export * from './common/interfaces/product-price-integration-updated.interface';
+export * from './common/interfaces/product-stock-integration-updated.interface';
+export * from './common/interfaces/product-image-integration-updated.interface';
+export * from './common/interfaces/product-export.interface';
+export * from './common/interfaces/invoice-export.interface';
+export * from './common/interfaces/shipment-export.interface';
+export * from './common/interfaces/order-integration-created.interface';
+export * from './common/interfaces/order-integration-status-updated.interface';
+export * from './common/interfaces/api-client.interface';
+export * from './common/interfaces/external-location.interface';

--- a/dist/common-client.js
+++ b/dist/common-client.js
@@ -1,0 +1,77 @@
+"use strict";
+/**
+ * common-client.ts — Frontend-safe entry point
+ *
+ * Bu dosya sadece client (Next.js) tarafından kullanılacak
+ * frontend-safe export'ları içerir. Backend-specific bağımlılıklar
+ * (Mongoose, NATS, Redis vb.) bu entry point'ten hariç tutulmuştur.
+ */
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Subjects = void 0;
+// ========== Types / Enums ==========
+__exportStar(require("./common/types/address-type"), exports);
+__exportStar(require("./common/types/attributes-type"), exports);
+__exportStar(require("./common/types/common.types"), exports);
+__exportStar(require("./common/types/credential-type"), exports);
+__exportStar(require("./common/types/credential-group"), exports);
+__exportStar(require("./common/types/currency-code"), exports);
+__exportStar(require("./common/types/currency-symbol"), exports);
+__exportStar(require("./common/types/entity.types"), exports);
+__exportStar(require("./common/types/fix-status"), exports);
+__exportStar(require("./common/types/integration-status"), exports);
+__exportStar(require("./common/types/integration-type"), exports);
+__exportStar(require("./common/types/integration-limits"), exports);
+__exportStar(require("./common/types/number-comparisons-type"), exports);
+__exportStar(require("./common/types/resourceName"), exports);
+__exportStar(require("./common/types/sort-type"), exports);
+__exportStar(require("./common/types/stock-action-type"), exports);
+__exportStar(require("./common/types/unit-type"), exports);
+__exportStar(require("./common/types/user-role"), exports);
+__exportStar(require("./common/types/permission.types"), exports);
+__exportStar(require("./common/types/integration-params"), exports);
+__exportStar(require("./common/types/cron-defaults"), exports);
+// ========== Event Types (pure enums, no backend deps) ==========
+__exportStar(require("./common/events/types/order-status"), exports);
+__exportStar(require("./common/events/types/order-status2"), exports);
+__exportStar(require("./common/events/types/order-type"), exports);
+__exportStar(require("./common/events/types/product-type"), exports);
+__exportStar(require("./common/events/types/product-status"), exports);
+__exportStar(require("./common/events/types/payment-type"), exports);
+__exportStar(require("./common/events/types/return-status"), exports);
+__exportStar(require("./common/events/types/invoice-status"), exports);
+// ========== Event Subjects (WebSocket/real-time için) ==========
+var subjects_1 = require("./common/events/subjects");
+Object.defineProperty(exports, "Subjects", { enumerable: true, get: function () { return subjects_1.Subjects; } });
+// ========== Constants ==========
+__exportStar(require("./common/constants/cargo-label-support.constants"), exports);
+__exportStar(require("./common/constants/integration-commands"), exports);
+// ========== Interfaces (frontend-safe olanlar) ==========
+__exportStar(require("./common/interfaces/validator-func-params.interface"), exports);
+__exportStar(require("./common/interfaces/integration-instance.interface"), exports);
+__exportStar(require("./common/interfaces/product-integration-created.interface"), exports);
+__exportStar(require("./common/interfaces/product-price-integration-updated.interface"), exports);
+__exportStar(require("./common/interfaces/product-stock-integration-updated.interface"), exports);
+__exportStar(require("./common/interfaces/product-image-integration-updated.interface"), exports);
+__exportStar(require("./common/interfaces/product-export.interface"), exports);
+__exportStar(require("./common/interfaces/invoice-export.interface"), exports);
+__exportStar(require("./common/interfaces/shipment-export.interface"), exports);
+__exportStar(require("./common/interfaces/order-integration-created.interface"), exports);
+__exportStar(require("./common/interfaces/order-integration-status-updated.interface"), exports);
+__exportStar(require("./common/interfaces/api-client.interface"), exports);
+__exportStar(require("./common/interfaces/external-location.interface"), exports);
+// NOT: entity-deletion.interface ve batch-deletion.interface
+// Mongoose ClientSession bağımlılığı nedeniyle hariç tutulmuştur.

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
       "default": "./dist/index.js"
     },
     "./common-client": {
-      "types": "./dist-client/common-client.d.ts",
-      "default": "./dist-client/common-client.js"
+      "types": "./dist/common-client.d.ts",
+      "default": "./dist/common-client.js"
     }
   },
   "scripts": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,6 @@
 	"exclude": [
 		"**/*.test.ts",
 		"src/test/**/*",
-		"src/common-client.ts",
 		"dist",
 		"dist-client"
 	]


### PR DESCRIPTION
Production Docker build'de dist-client/ oluşmuyordu çünkü base image
eski build:all script'ini cache'liyordu. common-client.ts artık ana
tsc build'e dahil — dist/common-client.js her zaman oluşur.

## Değişiklikler
- tsconfig.json: common-client.ts exclude kaldırıldı
- common-client.js proxy: dist-client → dist yönlendirmesi
- package.json exports: dist-client → dist path'i