### PR TITLE
fix: redisWrapper type — Record → object (issue #512)

### DIFF
--- a/dist/services/redisWrapper.service.d.ts
+++ b/dist/services/redisWrapper.service.d.ts
@@ -6,13 +6,13 @@ declare class RedisWrapper {
     get client(): RedisClientType;
     connect(url: string, timeoutMs?: number): Promise<void>;
     deleteOrder(userId: string, purchaseNumber: string, platformNumber: string): Promise<boolean>;
-    setOrder(userId: string, purchaseNumber: string, platformNumber: string, orderData: Record<string, unknown>): Promise<void>;
+    setOrder(userId: string, purchaseNumber: string, platformNumber: string, orderData: object): Promise<void>;
     getOrder(userId: string, purchaseNumber: string, platformNumber: string): Promise<{
         [x: string]: string;
     } | null>;
     updateOrderStatus(userId: string, purchaseNumber: string, platformNumber: string, status: string): Promise<void>;
     deleteCredentials(userId: string, platform: string): Promise<void>;
-    setCredentials(userId: string, platform: string, credentials: Record<string, unknown>): Promise<void>;
+    setCredentials(userId: string, platform: string, credentials: object): Promise<void>;
     getCredentials(userId: string, platform: string): Promise<{
         [x: string]: string;
     } | null>;

--- a/src/services/redisWrapper.service.ts
+++ b/src/services/redisWrapper.service.ts
@@ -129,7 +129,7 @@ class RedisWrapper {
         return false;
     }
 
-    async setOrder(userId: string, purchaseNumber: string, platformNumber: string, orderData: Record<string, unknown>) {
+    async setOrder(userId: string, purchaseNumber: string, platformNumber: string, orderData: object) {
         const key = `user:${userId}:order:${purchaseNumber}:${platformNumber}`;
         await this.client.hSet(key, this.toHashFields(orderData));
     }
@@ -155,7 +155,7 @@ class RedisWrapper {
         }
     }
 
-    async setCredentials(userId: string, platform: string, credentials: Record<string, unknown>) {
+    async setCredentials(userId: string, platform: string, credentials: object) {
         const key = `user:${userId}:platform:${platform}:credentials`;
         await this.client.hSet(key, this.toHashFields(credentials));
     }
@@ -202,7 +202,7 @@ class RedisWrapper {
      * Objeyi Redis hash field'larına dönüştürür — double serialization olmadan.
      * undefined/null değerleri atlar, nested objeleri JSON.stringify ile serialize eder.
      */
-    private toHashFields(data: Record<string, unknown>): Record<string, string> {
+    private toHashFields(data: object): Record<string, string> {
         const result: Record<string, string> = {};
         for (const [key, value] of Object.entries(data)) {
             if (value === undefined || value === null) continue;


### PR DESCRIPTION
## Özet
Orders servis build hatası düzeltmesi. Faz 2'de setOrder/setCredentials type'ı `any` → `Record<string, unknown>` yapılmıştı, ama `OrderRedisData` gibi named interface'ler TypeScript'te Record ile uyumsuz (index signature eksik). `object` type ile çözüldü.

## İlgili Moon PR
Ana repo PR'ı oluşturulacak.

---
*Bu PR `/work 512` komutu ile oluşturulmuştur.*