### PR TITLE
feat: MongoDB slow query detection (issue #512)

### DIFF
--- a/dist/models/base/base.schema.js
+++ b/dist/models/base/base.schema.js
@@ -348,6 +348,31 @@ function createBaseSchema(schemaDefinition = {}, options = {}) {
             addIdToLeanDoc(doc);
         }
     });
+    // Slow Query Detection — 100ms üzeri sorgular loglanır
+    const SLOW_QUERY_THRESHOLD_MS = parseInt(process.env.SLOW_QUERY_THRESHOLD_MS || '100', 10);
+    const queryTypes = ['find', 'findOne', 'countDocuments', 'distinct'];
+    for (const queryType of queryTypes) {
+        baseSchema.pre(queryType, function () {
+            this._startTime = Date.now();
+        });
+        baseSchema.post(queryType, function () {
+            var _a, _b;
+            if (!this._startTime)
+                return;
+            const duration = Date.now() - this._startTime;
+            if (duration > SLOW_QUERY_THRESHOLD_MS) {
+                const modelName = ((_a = this.model) === null || _a === void 0 ? void 0 : _a.modelName) || 'Unknown';
+                const filter = JSON.stringify(((_b = this.getQuery) === null || _b === void 0 ? void 0 : _b.call(this)) || {}).substring(0, 200);
+                logger_service_1.logger.warn(`🐢 Slow query detected: ${modelName}.${queryType} — ${duration}ms`, {
+                    model: modelName,
+                    operation: queryType,
+                    duration,
+                    filter,
+                    service: process.env.SERVICE_NAME || 'unknown'
+                });
+            }
+        });
+    }
     baseSchema.methods.destroy = function () {
         return __awaiter(this, void 0, void 0, function* () {
             try {

--- a/src/models/base/base.schema.ts
+++ b/src/models/base/base.schema.ts
@@ -427,6 +427,32 @@ export function createBaseSchema(
         if ((this as any).mongooseOptions().lean && doc) { addIdToLeanDoc(doc); }
     });
 
+    // Slow Query Detection — 100ms üzeri sorgular loglanır
+    const SLOW_QUERY_THRESHOLD_MS = parseInt(process.env.SLOW_QUERY_THRESHOLD_MS || '100', 10);
+
+    const queryTypes = ['find', 'findOne', 'countDocuments', 'distinct'] as const;
+    for (const queryType of queryTypes) {
+        baseSchema.pre(queryType, function (this: any) {
+            this._startTime = Date.now();
+        });
+
+        baseSchema.post(queryType, function (this: any) {
+            if (!this._startTime) return;
+            const duration = Date.now() - this._startTime;
+            if (duration > SLOW_QUERY_THRESHOLD_MS) {
+                const modelName = this.model?.modelName || 'Unknown';
+                const filter = JSON.stringify(this.getQuery?.() || {}).substring(0, 200);
+                logger.warn(`🐢 Slow query detected: ${modelName}.${queryType} — ${duration}ms`, {
+                    model: modelName,
+                    operation: queryType,
+                    duration,
+                    filter,
+                    service: process.env.SERVICE_NAME || 'unknown'
+                });
+            }
+        });
+    }
+
     baseSchema.methods.destroy = async function(): Promise<EmitReturnConfig | undefined> {
         try {
             const instance = this as BaseDoc;


### PR DESCRIPTION
## Özet
createBaseSchema'ya slow query detection hook'ları eklendi. 100ms üzeri MongoDB sorguları otomatik olarak loglanır.

## Nasıl Çalışır
- find, findOne, countDocuments, distinct operasyonları pre/post hook ile izlenir
- Süre 100ms'i aşarsa `logger.warn` ile loglanır
- Log: model adı, operasyon, süre, filtre (ilk 200 karakter)
- Threshold env ile ayarlanabilir: `SLOW_QUERY_THRESHOLD_MS=200`

## Etki
Tüm servisler otomatik olarak bu özelliğe sahip olur — createBaseSchema her serviste kullanıldığı için.

---
*Bu PR `/work 512` komutu ile oluşturulmuştur.*