### PR TITLE
fix(resource-name): TSoft -> "T-Soft" enum value (issue #545 follow-up)

### DIFF
--- a/dist/common/types/resourceName.d.ts
+++ b/dist/common/types/resourceName.d.ts
@@ -12,5 +12,5 @@ export declare enum ResourceName {
     HepsiJet = "HepsiJet",
     Ikas = "Ikas",
     IdeaSoft = "IdeaSoft",
-    TSoft = "TSoft"
+    TSoft = "T-Soft"
 }

--- a/dist/common/types/resourceName.js
+++ b/dist/common/types/resourceName.js
@@ -16,5 +16,5 @@ var ResourceName;
     ResourceName["HepsiJet"] = "HepsiJet";
     ResourceName["Ikas"] = "Ikas";
     ResourceName["IdeaSoft"] = "IdeaSoft";
-    ResourceName["TSoft"] = "TSoft";
+    ResourceName["TSoft"] = "T-Soft";
 })(ResourceName || (exports.ResourceName = ResourceName = {}));

--- a/src/common/types/resourceName.ts
+++ b/src/common/types/resourceName.ts
@@ -12,5 +12,5 @@ export enum ResourceName {
     HepsiJet = "HepsiJet",
     Ikas = "Ikas",
     IdeaSoft = "IdeaSoft",
-    TSoft = "TSoft",
+    TSoft = "T-Soft",
 }


### PR DESCRIPTION
## Ozet

Kullanici TSoft test panelinde "T-Soft" entegrasyon ismini sectiginde validation hatasi aldi:

\`\`\`
errors.validation.invalidValue::Integration Name::Main,Trendyol,Hepsiburada,N11,
CicekSepeti,Amazon,Shopify,Parasut,Aras,Yurtici,HepsiJet,Ikas,IdeaSoft,TSoft
\`\`\`

T-Soft markanin resmi adi **tireli** (\"T-Soft\"). ResourceName.TSoft enum
value \"TSoft\" -> \"T-Soft\" olarak guncellendi.

## Etki

- Enum: \`ResourceName.TSoft = "T-Soft"\` (onceden \"TSoft\")
- TypeScript referansi: \`ResourceName.TSoft\` symbol degismez (sadece string value)
- NATS subject: \`integration:ecommerce:tsoft:command\` lowercase teknik naming, AYNI kalir
- Redis key prefix: \`tsoft:token:...\` lowercase, AYNI
- Secret name: \`tsoft-mongodb-secret\` lowercase, AYNI
- File name: \`tsoft.integration.ts\` vb. lowercase, AYNI
- Service name: \`'tsoft'\` (logger, security service id) lowercase, AYNI

Sadece kullanici-gorunumlu enum string degeri "T-Soft" oldu.

## Ana Repo

Ana repo PR (#546)'da:
- \`integrationTemplates.ts\` template key: \`'tsoft'\` -> \`'t-soft'\`
- \`integration-templates.js\` template key: \`'tsoft'\` -> \`'t-soft'\`

(Cunku \`getIntegrationTemplate\` lookup \`integrationName.toLowerCase()\` ile yapiyor:
"T-Soft".toLowerCase() = "t-soft")

Submodule pointer ana repo'da bu PR merge edildikten sonra guncellenecek.

---
*Issue #545 follow-up.*