### PR TITLE
feat: ciceksepeti security logger + cargo label helper (issue #557)

### DIFF
--- a/dist/common/constants/cargo-label-support.constants.d.ts
+++ b/dist/common/constants/cargo-label-support.constants.d.ts
@@ -37,6 +37,22 @@ export declare const TRENDYOL_SUPPORTED_CARGOS: string[];
  * @returns true: Destekliyor, false: Desteklemiyor
  */
 export declare function hasTrendyolLabelSupport(cargoProviderCode: string | undefined | null): boolean;
+/**
+ * Çiçeksepeti ortak etiket destekleyen kargo firmaları
+ * NOT: Çiçeksepeti dokümantasyonunda kesin liste belirtilmediğinden,
+ * şimdilik konservatif yaklaşımla tüm kargo firmaları destekleniyor kabul ediliyor.
+ * Kesin liste netleştiğinde (issue #557 sonrası) bu liste güncellenmeli.
+ */
+export declare const CICEKSEPETI_SUPPORTED_CARGOS: string[];
+/**
+ * Çiçeksepeti kargo firmasının ortak etiket desteği var mı kontrol eder
+ * @param cargoProviderCode - Kargo firma kodu
+ * @returns true: Destekliyor, false: Desteklemiyor
+ *
+ * NOT: Şu anda Çiçeksepeti kargo destek listesi netleşmediği için
+ * konservatif olarak false döndürülmektedir. Liste netleştiğinde güncelleme gerekir.
+ */
+export declare function hasCicekSepetiLabelSupport(cargoProviderCode: string | undefined | null): boolean;
 /** Kargo barkod desteği olmadığında gösterilecek mesajlar */
 export declare const CARGO_NO_LABEL_MESSAGES: {
     /** Hepsiburada - Desteklenmeyen kargo firması */
@@ -45,6 +61,8 @@ export declare const CARGO_NO_LABEL_MESSAGES: {
     hepsiburada_store_account: string;
     /** Trendyol - Desteklenmeyen kargo firması */
     trendyol_no_support: string;
+    /** Çiçeksepeti - Desteklenmeyen kargo firması */
+    ciceksepeti_no_support: string;
     /** Genel mesaj */
     generic: string;
 };

--- a/dist/common/constants/cargo-label-support.constants.js
+++ b/dist/common/constants/cargo-label-support.constants.js
@@ -15,10 +15,11 @@
  * - Diğer kargo firmaları ortak etiket API'sini desteklemiyor
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.CARGO_NO_LABEL_MESSAGES = exports.TRENDYOL_SUPPORTED_CARGOS = exports.HEPSIBURADA_STORE_ACCOUNT_ID = exports.HEPSIBURADA_SUPPORTED_CARGOS = void 0;
+exports.CARGO_NO_LABEL_MESSAGES = exports.CICEKSEPETI_SUPPORTED_CARGOS = exports.TRENDYOL_SUPPORTED_CARGOS = exports.HEPSIBURADA_STORE_ACCOUNT_ID = exports.HEPSIBURADA_SUPPORTED_CARGOS = void 0;
 exports.hasHepsiburadaLabelSupport = hasHepsiburadaLabelSupport;
 exports.isHepsiburadaStoreAccount = isHepsiburadaStoreAccount;
 exports.hasTrendyolLabelSupport = hasTrendyolLabelSupport;
+exports.hasCicekSepetiLabelSupport = hasCicekSepetiLabelSupport;
 exports.getCargoNoLabelMessage = getCargoNoLabelMessage;
 // ===== HEPSIBURADA KARGO DESTEĞİ =====
 /** Hepsiburada ortak barkod destekleyen kargo firmaları */
@@ -61,6 +62,30 @@ function hasTrendyolLabelSupport(cargoProviderCode) {
     const lowerCode = cargoProviderCode.toLowerCase();
     return lowerCode.includes('tex') || lowerCode.includes('trendyol') || lowerCode.includes('aras');
 }
+// ===== ÇİÇEKSEPETİ KARGO DESTEĞİ =====
+/**
+ * Çiçeksepeti ortak etiket destekleyen kargo firmaları
+ * NOT: Çiçeksepeti dokümantasyonunda kesin liste belirtilmediğinden,
+ * şimdilik konservatif yaklaşımla tüm kargo firmaları destekleniyor kabul ediliyor.
+ * Kesin liste netleştiğinde (issue #557 sonrası) bu liste güncellenmeli.
+ */
+exports.CICEKSEPETI_SUPPORTED_CARGOS = [];
+/**
+ * Çiçeksepeti kargo firmasının ortak etiket desteği var mı kontrol eder
+ * @param cargoProviderCode - Kargo firma kodu
+ * @returns true: Destekliyor, false: Desteklemiyor
+ *
+ * NOT: Şu anda Çiçeksepeti kargo destek listesi netleşmediği için
+ * konservatif olarak false döndürülmektedir. Liste netleştiğinde güncelleme gerekir.
+ */
+function hasCicekSepetiLabelSupport(cargoProviderCode) {
+    if (!cargoProviderCode)
+        return false;
+    if (exports.CICEKSEPETI_SUPPORTED_CARGOS.length === 0)
+        return false;
+    const lowerCode = cargoProviderCode.toLowerCase();
+    return exports.CICEKSEPETI_SUPPORTED_CARGOS.some(c => lowerCode.includes(c.toLowerCase()));
+}
 // ===== KULLANICI DOSTU HATA MESAJLARI =====
 /** Kargo barkod desteği olmadığında gösterilecek mesajlar */
 exports.CARGO_NO_LABEL_MESSAGES = {
@@ -70,6 +95,8 @@ exports.CARGO_NO_LABEL_MESSAGES = {
     hepsiburada_store_account: 'Mağaza Hesabı siparişlerinde platform etiketi kullanılamaz.',
     /** Trendyol - Desteklenmeyen kargo firması */
     trendyol_no_support: 'Bu kargo firması ortak etiket desteklemiyor. Sadece TEX ve Aras (trendyol öder) destekliyor.',
+    /** Çiçeksepeti - Desteklenmeyen kargo firması */
+    ciceksepeti_no_support: 'Bu kargo firması Çiçeksepeti ortak etiket desteği sunmuyor.',
     /** Genel mesaj */
     generic: 'Bu kargo firması platform üzerinden barkod desteği sunmuyor.'
 };
@@ -87,6 +114,9 @@ function getCargoNoLabelMessage(platform, isStoreAccount = false) {
     }
     if (platform.toLowerCase().includes('trendyol')) {
         return exports.CARGO_NO_LABEL_MESSAGES.trendyol_no_support;
+    }
+    if (platform.toLowerCase().includes('ciceksepeti') || platform.toLowerCase().includes('çiçeksepeti')) {
+        return exports.CARGO_NO_LABEL_MESSAGES.ciceksepeti_no_support;
     }
     return exports.CARGO_NO_LABEL_MESSAGES.generic;
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -32,6 +32,7 @@ export * from './services/response-interpreters/hepsiburada.interpreter';
 export * from './services/response-interpreters/ikas.interpreter';
 export * from './services/response-interpreters/hepsijet.interpreter';
 export * from './services/response-interpreters/tsoft.interpreter';
+export * from './services/response-interpreters/ciceksepeti.interpreter';
 export * from './services/response-interpreters/interpreter.factory';
 export * from './enums/operation-type.enum';
 export * from './common/enums/aras-status.enum';

--- a/dist/index.js
+++ b/dist/index.js
@@ -59,6 +59,7 @@ __exportStar(require("./services/response-interpreters/hepsiburada.interpreter")
 __exportStar(require("./services/response-interpreters/ikas.interpreter"), exports);
 __exportStar(require("./services/response-interpreters/hepsijet.interpreter"), exports);
 __exportStar(require("./services/response-interpreters/tsoft.interpreter"), exports);
+__exportStar(require("./services/response-interpreters/ciceksepeti.interpreter"), exports);
 __exportStar(require("./services/response-interpreters/interpreter.factory"), exports);
 // Enums
 __exportStar(require("./enums/operation-type.enum"), exports);

--- a/dist/security-logger/SecurityLogger.d.ts
+++ b/dist/security-logger/SecurityLogger.d.ts
@@ -70,3 +70,4 @@ export declare const trendyolSecurityLogger: SecurityLogger;
 export declare const hepsiburadaSecurityLogger: SecurityLogger;
 export declare const ikasSecurityLogger: SecurityLogger;
 export declare const tsoftSecurityLogger: SecurityLogger;
+export declare const ciceksepetiSecurityLogger: SecurityLogger;

--- a/dist/security-logger/SecurityLogger.js
+++ b/dist/security-logger/SecurityLogger.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.tsoftSecurityLogger = exports.ikasSecurityLogger = exports.hepsiburadaSecurityLogger = exports.trendyolSecurityLogger = exports.shopifySecurityLogger = exports.cdnSecurityLogger = exports.integrationSecurityLogger = exports.pricingSecurityLogger = exports.productsSecurityLogger = exports.inventorySecurityLogger = exports.ordersSecurityLogger = exports.catalogSecurityLogger = exports.authSecurityLogger = exports.SecurityLogger = void 0;
+exports.ciceksepetiSecurityLogger = exports.tsoftSecurityLogger = exports.ikasSecurityLogger = exports.hepsiburadaSecurityLogger = exports.trendyolSecurityLogger = exports.shopifySecurityLogger = exports.cdnSecurityLogger = exports.integrationSecurityLogger = exports.pricingSecurityLogger = exports.productsSecurityLogger = exports.inventorySecurityLogger = exports.ordersSecurityLogger = exports.catalogSecurityLogger = exports.authSecurityLogger = exports.SecurityLogger = void 0;
 exports.createSecurityLogger = createSecurityLogger;
 const SecurityEventTypes_1 = require("./SecurityEventTypes");
 /**
@@ -211,3 +211,4 @@ exports.trendyolSecurityLogger = new SecurityLogger('trendyol');
 exports.hepsiburadaSecurityLogger = new SecurityLogger('hepsiburada');
 exports.ikasSecurityLogger = new SecurityLogger('ikas');
 exports.tsoftSecurityLogger = new SecurityLogger('tsoft');
+exports.ciceksepetiSecurityLogger = new SecurityLogger('ciceksepeti');

--- a/dist/security-logger/index.d.ts
+++ b/dist/security-logger/index.d.ts
@@ -5,5 +5,5 @@
  * Provides structured logging capabilities to replace console.error usage
  * and enable comprehensive security monitoring and alerting.
  */
-export { SecurityLogger, createSecurityLogger, authSecurityLogger, catalogSecurityLogger, ordersSecurityLogger, inventorySecurityLogger, productsSecurityLogger, pricingSecurityLogger, integrationSecurityLogger, cdnSecurityLogger, shopifySecurityLogger, trendyolSecurityLogger, hepsiburadaSecurityLogger, ikasSecurityLogger, tsoftSecurityLogger } from './SecurityLogger';
+export { SecurityLogger, createSecurityLogger, authSecurityLogger, catalogSecurityLogger, ordersSecurityLogger, inventorySecurityLogger, productsSecurityLogger, pricingSecurityLogger, integrationSecurityLogger, cdnSecurityLogger, shopifySecurityLogger, trendyolSecurityLogger, hepsiburadaSecurityLogger, ikasSecurityLogger, tsoftSecurityLogger, ciceksepetiSecurityLogger } from './SecurityLogger';
 export { SecurityEventType, SecurityEventSeverity, SecurityEventMetadata, SecurityLogEntry, SecurityMetricsData, getEventSeverity } from './SecurityEventTypes';

--- a/dist/security-logger/index.js
+++ b/dist/security-logger/index.js
@@ -7,7 +7,7 @@
  * and enable comprehensive security monitoring and alerting.
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getEventSeverity = exports.SecurityEventSeverity = exports.SecurityEventType = exports.tsoftSecurityLogger = exports.ikasSecurityLogger = exports.hepsiburadaSecurityLogger = exports.trendyolSecurityLogger = exports.shopifySecurityLogger = exports.cdnSecurityLogger = exports.integrationSecurityLogger = exports.pricingSecurityLogger = exports.productsSecurityLogger = exports.inventorySecurityLogger = exports.ordersSecurityLogger = exports.catalogSecurityLogger = exports.authSecurityLogger = exports.createSecurityLogger = exports.SecurityLogger = void 0;
+exports.getEventSeverity = exports.SecurityEventSeverity = exports.SecurityEventType = exports.ciceksepetiSecurityLogger = exports.tsoftSecurityLogger = exports.ikasSecurityLogger = exports.hepsiburadaSecurityLogger = exports.trendyolSecurityLogger = exports.shopifySecurityLogger = exports.cdnSecurityLogger = exports.integrationSecurityLogger = exports.pricingSecurityLogger = exports.productsSecurityLogger = exports.inventorySecurityLogger = exports.ordersSecurityLogger = exports.catalogSecurityLogger = exports.authSecurityLogger = exports.createSecurityLogger = exports.SecurityLogger = void 0;
 var SecurityLogger_1 = require("./SecurityLogger");
 Object.defineProperty(exports, "SecurityLogger", { enumerable: true, get: function () { return SecurityLogger_1.SecurityLogger; } });
 Object.defineProperty(exports, "createSecurityLogger", { enumerable: true, get: function () { return SecurityLogger_1.createSecurityLogger; } });
@@ -24,6 +24,7 @@ Object.defineProperty(exports, "trendyolSecurityLogger", { enumerable: true, get
 Object.defineProperty(exports, "hepsiburadaSecurityLogger", { enumerable: true, get: function () { return SecurityLogger_1.hepsiburadaSecurityLogger; } });
 Object.defineProperty(exports, "ikasSecurityLogger", { enumerable: true, get: function () { return SecurityLogger_1.ikasSecurityLogger; } });
 Object.defineProperty(exports, "tsoftSecurityLogger", { enumerable: true, get: function () { return SecurityLogger_1.tsoftSecurityLogger; } });
+Object.defineProperty(exports, "ciceksepetiSecurityLogger", { enumerable: true, get: function () { return SecurityLogger_1.ciceksepetiSecurityLogger; } });
 var SecurityEventTypes_1 = require("./SecurityEventTypes");
 Object.defineProperty(exports, "SecurityEventType", { enumerable: true, get: function () { return SecurityEventTypes_1.SecurityEventType; } });
 Object.defineProperty(exports, "SecurityEventSeverity", { enumerable: true, get: function () { return SecurityEventTypes_1.SecurityEventSeverity; } });

--- a/dist/services/response-interpreters/ciceksepeti.interpreter.d.ts
+++ b/dist/services/response-interpreters/ciceksepeti.interpreter.d.ts
@@ -56,6 +56,23 @@ export declare class CicekSepetiResponseInterpreter extends BaseResponseInterpre
      */
     private interpretCategoryAttributes;
     /**
+     * READ operation — birden fazla endpoint kullanıyor (sellerquestions, actions vb.)
+     * Response yapısına göre discriminate edilir.
+     */
+    private interpretRead;
+    /**
+     * Soru listesi yanıtını yorumla
+     * Response: { items: [{id, product, question, answer, answered, ...}], hasNextPage: boolean }
+     * Kaynak: docs/integrations/ciceksepeti/pages/019-ürün-sorularını-çekme.md
+     */
+    private interpretQuestionList;
+    /**
+     * BranchAction listesi yanıtını yorumla
+     * Response: { actions: [{name, value, details: [...]}] } veya direkt array
+     * Kaynak: docs/integrations/ciceksepeti/pages/020-ürün-sorularını-cevaplama.md
+     */
+    private interpretActionsList;
+    /**
      * Genel yanıt yorumlama
      */
     private interpretGeneric;

--- a/dist/services/response-interpreters/ciceksepeti.interpreter.d.ts
+++ b/dist/services/response-interpreters/ciceksepeti.interpreter.d.ts
@@ -1,0 +1,62 @@
+import { OperationType } from '../../enums/operation-type.enum';
+import { InterpretedResponse } from '../../models/integrationRequestLog.schema';
+import { BaseResponseInterpreter } from './base.interpreter';
+/**
+ * Çiçeksepeti API response interpreter
+ *
+ * Çiçeksepeti API'sinin response yapıları:
+ *   - Order/GetOrders → { orderListCount, supplierOrderListWithBranch: [...] }
+ *   - Order/getcanceledorders → { orderItemList: [...] }
+ *   - Order/cancelevaluation → { isSuccess, message }
+ *   - Order/refundprocessstartreceivedprocess → { orderItems: [...] }
+ *   - Products POST/PUT/price-and-stock → { batchId } (async)
+ *   - Products/batch-status/{batchId} → { batchId, itemCount, items: [{status: "Pending|Processing|Success|Failed|Warning"}] }
+ *   - Products GET → { totalCount, products: [...] }
+ *   - Categories GET → { categories: [...] (tree) }
+ *   - Categories/{id}/attributes → { categoryAttributes: [...] }
+ *   - sellerquestions GET → { items: [...], hasNextPage }
+ */
+export declare class CicekSepetiResponseInterpreter extends BaseResponseInterpreter {
+    interpret(response: any, operationType: OperationType): InterpretedResponse | null;
+    /**
+     * Batch submit yanıtını yorumla — POST /Products, PUT /Products, PUT /Products/price-and-stock
+     * Response: { batchId: "uuid-..." }
+     */
+    private interpretBatchSubmit;
+    /**
+     * Batch status yanıtını yorumla
+     * Response: { batchId, itemCount, items: [{itemId, status: "Pending|Processing|Success|Failed|Warning", failureReasons}] }
+     */
+    private interpretBatchStatus;
+    /**
+     * Ürün listeleme yanıtını yorumla
+     * Response: { totalCount, products: [...] }
+     */
+    private interpretProductList;
+    /**
+     * Sipariş veya iade listeleme yanıtını yorumla
+     * Order/GetOrders → { orderListCount, supplierOrderListWithBranch: [...] }
+     * Order/getcanceledorders → { orderItemList: [...] }
+     */
+    private interpretOrderOrRefundList;
+    /**
+     * Sipariş güncelleme yanıtını yorumla
+     * Order/cancelevaluation → { isSuccess, message }
+     * Order/refundprocessstartreceivedprocess → { orderItems: [{orderItemId, isSuccess, validation}] }
+     */
+    private interpretOrderUpdate;
+    /**
+     * Kategori listesi yanıtını yorumla (tree yapısı)
+     * Response: { categories: [{id, name, parentCategoryId, subCategories: [...]}] }
+     */
+    private interpretCategoryList;
+    /**
+     * Kategori öznitelik yanıtını yorumla
+     * Response: { categoryId, categoryName, categoryAttributes: [...] }
+     */
+    private interpretCategoryAttributes;
+    /**
+     * Genel yanıt yorumlama
+     */
+    private interpretGeneric;
+}

--- a/dist/services/response-interpreters/ciceksepeti.interpreter.js
+++ b/dist/services/response-interpreters/ciceksepeti.interpreter.js
@@ -44,6 +44,8 @@ class CicekSepetiResponseInterpreter extends base_interpreter_1.BaseResponseInte
                     return this.interpretCategoryList(response);
                 case operation_type_enum_1.OperationType.GET_CATEGORY_ATTRIBUTES:
                     return this.interpretCategoryAttributes(response);
+                case operation_type_enum_1.OperationType.READ:
+                    return this.interpretRead(response, operationType);
                 default:
                     return this.interpretGeneric(response, operationType);
             }
@@ -277,6 +279,63 @@ class CicekSepetiResponseInterpreter extends base_interpreter_1.BaseResponseInte
                 attributeCount: attributes.length,
                 requiredCount,
                 variantCount
+            },
+            parsedAt: new Date()
+        };
+    }
+    /**
+     * READ operation — birden fazla endpoint kullanıyor (sellerquestions, actions vb.)
+     * Response yapısına göre discriminate edilir.
+     */
+    interpretRead(response, operationType) {
+        // /sellerquestions GET → { items: [...], hasNextPage: boolean }
+        if (Array.isArray(response === null || response === void 0 ? void 0 : response.items) && typeof (response === null || response === void 0 ? void 0 : response.hasNextPage) === 'boolean') {
+            return this.interpretQuestionList(response);
+        }
+        // /sellerquestions/actions GET → { actions: [...] } veya array
+        if (Array.isArray(response === null || response === void 0 ? void 0 : response.actions) || Array.isArray(response)) {
+            return this.interpretActionsList(response);
+        }
+        return this.interpretGeneric(response, operationType);
+    }
+    /**
+     * Soru listesi yanıtını yorumla
+     * Response: { items: [{id, product, question, answer, answered, ...}], hasNextPage: boolean }
+     * Kaynak: docs/integrations/ciceksepeti/pages/019-ürün-sorularını-çekme.md
+     */
+    interpretQuestionList(response) {
+        const items = Array.isArray(response === null || response === void 0 ? void 0 : response.items) ? response.items : [];
+        const answeredCount = items.filter((q) => q.answered === true).length;
+        const unansweredCount = items.filter((q) => q.answered === false).length;
+        const hasNextPage = (response === null || response === void 0 ? void 0 : response.hasNextPage) === true;
+        return {
+            summary: `${items.length} ürün sorusu getirildi (${answeredCount} cevaplanmış, ${unansweredCount} cevaplanmamış)${hasNextPage ? ' — sonraki sayfa var' : ''}`,
+            success: true,
+            successCount: items.length,
+            details: {
+                pageItemCount: items.length,
+                answeredCount,
+                unansweredCount,
+                hasNextPage
+            },
+            parsedAt: new Date()
+        };
+    }
+    /**
+     * BranchAction listesi yanıtını yorumla
+     * Response: { actions: [{name, value, details: [...]}] } veya direkt array
+     * Kaynak: docs/integrations/ciceksepeti/pages/020-ürün-sorularını-cevaplama.md
+     */
+    interpretActionsList(response) {
+        const actions = Array.isArray(response === null || response === void 0 ? void 0 : response.actions)
+            ? response.actions
+            : (Array.isArray(response) ? response : []);
+        return {
+            summary: `${actions.length} branch action getirildi`,
+            success: true,
+            successCount: actions.length,
+            details: {
+                actionCount: actions.length
             },
             parsedAt: new Date()
         };

--- a/dist/services/response-interpreters/ciceksepeti.interpreter.js
+++ b/dist/services/response-interpreters/ciceksepeti.interpreter.js
@@ -1,0 +1,300 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.CicekSepetiResponseInterpreter = void 0;
+const operation_type_enum_1 = require("../../enums/operation-type.enum");
+const base_interpreter_1 = require("./base.interpreter");
+const logger_service_1 = require("../logger.service");
+/**
+ * Çiçeksepeti API response interpreter
+ *
+ * Çiçeksepeti API'sinin response yapıları:
+ *   - Order/GetOrders → { orderListCount, supplierOrderListWithBranch: [...] }
+ *   - Order/getcanceledorders → { orderItemList: [...] }
+ *   - Order/cancelevaluation → { isSuccess, message }
+ *   - Order/refundprocessstartreceivedprocess → { orderItems: [...] }
+ *   - Products POST/PUT/price-and-stock → { batchId } (async)
+ *   - Products/batch-status/{batchId} → { batchId, itemCount, items: [{status: "Pending|Processing|Success|Failed|Warning"}] }
+ *   - Products GET → { totalCount, products: [...] }
+ *   - Categories GET → { categories: [...] (tree) }
+ *   - Categories/{id}/attributes → { categoryAttributes: [...] }
+ *   - sellerquestions GET → { items: [...], hasNextPage }
+ */
+class CicekSepetiResponseInterpreter extends base_interpreter_1.BaseResponseInterpreter {
+    interpret(response, operationType) {
+        if (this.isEmptyResponse(response)) {
+            return null;
+        }
+        try {
+            switch (operationType) {
+                case operation_type_enum_1.OperationType.SEND_PRODUCTS:
+                case operation_type_enum_1.OperationType.UPDATE_PRODUCTS:
+                case operation_type_enum_1.OperationType.UPDATE_STOCK:
+                case operation_type_enum_1.OperationType.UPDATE_PRICES:
+                case operation_type_enum_1.OperationType.UPDATE_STOCK_AND_PRICE:
+                    return this.interpretBatchSubmit(response, operationType);
+                case operation_type_enum_1.OperationType.GET_BATCH_STATUS:
+                    return this.interpretBatchStatus(response);
+                case operation_type_enum_1.OperationType.FETCH_PRODUCTS:
+                    return this.interpretProductList(response);
+                case operation_type_enum_1.OperationType.FETCH_ORDERS:
+                    return this.interpretOrderOrRefundList(response);
+                case operation_type_enum_1.OperationType.UPDATE_ORDER:
+                    return this.interpretOrderUpdate(response);
+                case operation_type_enum_1.OperationType.GET_CATEGORIES:
+                    return this.interpretCategoryList(response);
+                case operation_type_enum_1.OperationType.GET_CATEGORY_ATTRIBUTES:
+                    return this.interpretCategoryAttributes(response);
+                default:
+                    return this.interpretGeneric(response, operationType);
+            }
+        }
+        catch (error) {
+            logger_service_1.logger.error('Error interpreting CicekSepeti response', {
+                operationType,
+                error: error.message
+            });
+            return null;
+        }
+    }
+    /**
+     * Batch submit yanıtını yorumla — POST /Products, PUT /Products, PUT /Products/price-and-stock
+     * Response: { batchId: "uuid-..." }
+     */
+    interpretBatchSubmit(response, operationType) {
+        const batchId = response === null || response === void 0 ? void 0 : response.batchId;
+        if (batchId) {
+            return {
+                summary: `Batch isteği oluşturuldu (Batch ID: ${batchId})`,
+                success: true,
+                successCount: 0, // gerçek sonuç batch-status üzerinden alınır
+                failureCount: 0,
+                details: {
+                    batchId,
+                    operationType
+                },
+                parsedAt: new Date()
+            };
+        }
+        // Hata durumu (Çiçeksepeti 4xx)
+        if ((response === null || response === void 0 ? void 0 : response.code) || (response === null || response === void 0 ? void 0 : response.message)) {
+            return {
+                summary: `Batch isteği başarısız: ${response.message || 'Bilinmeyen hata'}`,
+                success: false,
+                successCount: 0,
+                failureCount: 1,
+                details: {
+                    errorCode: response.code,
+                    errorMessage: response.message,
+                    operationType
+                },
+                parsedAt: new Date()
+            };
+        }
+        return this.interpretGeneric(response, operationType);
+    }
+    /**
+     * Batch status yanıtını yorumla
+     * Response: { batchId, itemCount, items: [{itemId, status: "Pending|Processing|Success|Failed|Warning", failureReasons}] }
+     */
+    interpretBatchStatus(response) {
+        var _a;
+        const items = Array.isArray(response === null || response === void 0 ? void 0 : response.items) ? response.items : [];
+        const successCount = items.filter((item) => item.status === 'Success').length;
+        const failureCount = items.filter((item) => item.status === 'Failed').length;
+        const warningCount = items.filter((item) => item.status === 'Warning').length;
+        const pendingCount = items.filter((item) => item.status === 'Pending' || item.status === 'Processing').length;
+        let summary = '';
+        if (pendingCount > 0) {
+            summary = `Batch durumu: ${successCount} başarılı, ${failureCount} başarısız, ${warningCount} uyarılı, ${pendingCount} beklemede`;
+        }
+        else {
+            summary = `Batch tamamlandı: ${successCount} başarılı, ${failureCount} başarısız, ${warningCount} uyarılı`;
+        }
+        return {
+            summary,
+            success: failureCount === 0,
+            successCount,
+            failureCount,
+            details: {
+                batchId: response === null || response === void 0 ? void 0 : response.batchId,
+                total: (_a = response === null || response === void 0 ? void 0 : response.itemCount) !== null && _a !== void 0 ? _a : items.length,
+                pending: pendingCount,
+                warning: warningCount,
+                failures: items
+                    .filter((item) => item.status === 'Failed')
+                    .map((item) => ({
+                    itemId: item.itemId,
+                    failureReasons: item.failureReasons,
+                    data: item.data
+                }))
+            },
+            parsedAt: new Date()
+        };
+    }
+    /**
+     * Ürün listeleme yanıtını yorumla
+     * Response: { totalCount, products: [...] }
+     */
+    interpretProductList(response) {
+        var _a;
+        const products = Array.isArray(response === null || response === void 0 ? void 0 : response.products) ? response.products : [];
+        const totalCount = (_a = response === null || response === void 0 ? void 0 : response.totalCount) !== null && _a !== void 0 ? _a : products.length;
+        return {
+            summary: `${totalCount} ürün getirildi (sayfa: ${products.length})`,
+            success: true,
+            successCount: products.length,
+            details: {
+                totalCount,
+                pageItemCount: products.length
+            },
+            parsedAt: new Date()
+        };
+    }
+    /**
+     * Sipariş veya iade listeleme yanıtını yorumla
+     * Order/GetOrders → { orderListCount, supplierOrderListWithBranch: [...] }
+     * Order/getcanceledorders → { orderItemList: [...] }
+     */
+    interpretOrderOrRefundList(response) {
+        var _a;
+        // Sipariş listesi
+        if (Array.isArray(response === null || response === void 0 ? void 0 : response.supplierOrderListWithBranch)) {
+            const items = response.supplierOrderListWithBranch;
+            const totalCount = (_a = response.orderListCount) !== null && _a !== void 0 ? _a : items.length;
+            return {
+                summary: `${totalCount} sipariş kaydı getirildi (sayfa: ${items.length})`,
+                success: true,
+                successCount: items.length,
+                details: {
+                    totalCount,
+                    pageItemCount: items.length
+                },
+                parsedAt: new Date()
+            };
+        }
+        // İade listesi
+        if (Array.isArray(response === null || response === void 0 ? void 0 : response.orderItemList)) {
+            const items = response.orderItemList;
+            return {
+                summary: `${items.length} iade siparişi getirildi`,
+                success: true,
+                successCount: items.length,
+                details: {
+                    pageItemCount: items.length
+                },
+                parsedAt: new Date()
+            };
+        }
+        return this.interpretGeneric(response, operation_type_enum_1.OperationType.FETCH_ORDERS);
+    }
+    /**
+     * Sipariş güncelleme yanıtını yorumla
+     * Order/cancelevaluation → { isSuccess, message }
+     * Order/refundprocessstartreceivedprocess → { orderItems: [{orderItemId, isSuccess, validation}] }
+     */
+    interpretOrderUpdate(response) {
+        // cancelevaluation single-result
+        if (typeof (response === null || response === void 0 ? void 0 : response.isSuccess) === 'boolean' && !Array.isArray(response === null || response === void 0 ? void 0 : response.orderItems)) {
+            return {
+                summary: response.isSuccess
+                    ? 'Sipariş güncelleme başarılı'
+                    : `Sipariş güncelleme başarısız: ${response.message || 'Bilinmeyen hata'}`,
+                success: response.isSuccess,
+                successCount: response.isSuccess ? 1 : 0,
+                failureCount: response.isSuccess ? 0 : 1,
+                details: {
+                    message: response.message
+                },
+                parsedAt: new Date()
+            };
+        }
+        // refundprocess multi-item
+        if (Array.isArray(response === null || response === void 0 ? void 0 : response.orderItems)) {
+            const items = response.orderItems;
+            const successCount = items.filter((x) => x.isSuccess === true).length;
+            const failureCount = items.filter((x) => x.isSuccess === false).length;
+            return {
+                summary: `${successCount} item başarılı, ${failureCount} başarısız`,
+                success: failureCount === 0,
+                successCount,
+                failureCount,
+                details: {
+                    items: items.map((x) => ({
+                        orderItemId: x.orderItemId,
+                        isSuccess: x.isSuccess,
+                        validation: x.validation
+                    }))
+                },
+                parsedAt: new Date()
+            };
+        }
+        return this.interpretGeneric(response, operation_type_enum_1.OperationType.UPDATE_ORDER);
+    }
+    /**
+     * Kategori listesi yanıtını yorumla (tree yapısı)
+     * Response: { categories: [{id, name, parentCategoryId, subCategories: [...]}] }
+     */
+    interpretCategoryList(response) {
+        const categories = Array.isArray(response === null || response === void 0 ? void 0 : response.categories) ? response.categories : [];
+        // Recursive flat count
+        const countNodes = (nodes) => {
+            let total = 0;
+            for (const node of nodes) {
+                total++;
+                if (Array.isArray(node.subCategories)) {
+                    total += countNodes(node.subCategories);
+                }
+            }
+            return total;
+        };
+        const totalNodes = countNodes(categories);
+        return {
+            summary: `${totalNodes} kategori (root: ${categories.length})`,
+            success: true,
+            successCount: totalNodes,
+            details: {
+                rootCount: categories.length,
+                totalCount: totalNodes
+            },
+            parsedAt: new Date()
+        };
+    }
+    /**
+     * Kategori öznitelik yanıtını yorumla
+     * Response: { categoryId, categoryName, categoryAttributes: [...] }
+     */
+    interpretCategoryAttributes(response) {
+        const attributes = Array.isArray(response === null || response === void 0 ? void 0 : response.categoryAttributes) ? response.categoryAttributes : [];
+        const requiredCount = attributes.filter((a) => a.required === true).length;
+        const variantCount = attributes.filter((a) => a.varianter === true).length;
+        return {
+            summary: `Kategori için ${attributes.length} özellik getirildi (${requiredCount} zorunlu, ${variantCount} varyant)`,
+            success: true,
+            successCount: attributes.length,
+            details: {
+                categoryId: response === null || response === void 0 ? void 0 : response.categoryId,
+                categoryName: response === null || response === void 0 ? void 0 : response.categoryName,
+                attributeCount: attributes.length,
+                requiredCount,
+                variantCount
+            },
+            parsedAt: new Date()
+        };
+    }
+    /**
+     * Genel yanıt yorumlama
+     */
+    interpretGeneric(response, operationType) {
+        return {
+            summary: `${operationType} işlemi tamamlandı`,
+            success: true,
+            details: {
+                operationType,
+                responseType: typeof response,
+                hasData: !this.isEmptyResponse(response)
+            },
+            parsedAt: new Date()
+        };
+    }
+}
+exports.CicekSepetiResponseInterpreter = CicekSepetiResponseInterpreter;

--- a/dist/services/response-interpreters/interpreter.factory.js
+++ b/dist/services/response-interpreters/interpreter.factory.js
@@ -10,6 +10,7 @@ const n11_interpreter_1 = require("./n11.interpreter");
 const ideasoft_interpreter_1 = require("./ideasoft.interpreter");
 const hepsijet_interpreter_1 = require("./hepsijet.interpreter");
 const tsoft_interpreter_1 = require("./tsoft.interpreter");
+const ciceksepeti_interpreter_1 = require("./ciceksepeti.interpreter");
 const logger_service_1 = require("../logger.service");
 /**
  * Response Interpreter Factory
@@ -50,6 +51,9 @@ class ResponseInterpreterFactory {
                 break;
             case common_1.ResourceName.TSoft:
                 interpreter = new tsoft_interpreter_1.TSoftResponseInterpreter();
+                break;
+            case common_1.ResourceName.CicekSepeti:
+                interpreter = new ciceksepeti_interpreter_1.CicekSepetiResponseInterpreter();
                 break;
             // Diğer platform'lar için ileride eklenebilir
             case common_1.ResourceName.Amazon:

--- a/src/common/constants/cargo-label-support.constants.ts
+++ b/src/common/constants/cargo-label-support.constants.ts
@@ -60,6 +60,31 @@ export function hasTrendyolLabelSupport(cargoProviderCode: string | undefined | 
     return lowerCode.includes('tex') || lowerCode.includes('trendyol') || lowerCode.includes('aras');
 }
 
+// ===== ÇİÇEKSEPETİ KARGO DESTEĞİ =====
+
+/**
+ * Çiçeksepeti ortak etiket destekleyen kargo firmaları
+ * NOT: Çiçeksepeti dokümantasyonunda kesin liste belirtilmediğinden,
+ * şimdilik konservatif yaklaşımla tüm kargo firmaları destekleniyor kabul ediliyor.
+ * Kesin liste netleştiğinde (issue #557 sonrası) bu liste güncellenmeli.
+ */
+export const CICEKSEPETI_SUPPORTED_CARGOS: string[] = [];
+
+/**
+ * Çiçeksepeti kargo firmasının ortak etiket desteği var mı kontrol eder
+ * @param cargoProviderCode - Kargo firma kodu
+ * @returns true: Destekliyor, false: Desteklemiyor
+ *
+ * NOT: Şu anda Çiçeksepeti kargo destek listesi netleşmediği için
+ * konservatif olarak false döndürülmektedir. Liste netleştiğinde güncelleme gerekir.
+ */
+export function hasCicekSepetiLabelSupport(cargoProviderCode: string | undefined | null): boolean {
+    if (!cargoProviderCode) return false;
+    if (CICEKSEPETI_SUPPORTED_CARGOS.length === 0) return false;
+    const lowerCode = cargoProviderCode.toLowerCase();
+    return CICEKSEPETI_SUPPORTED_CARGOS.some(c => lowerCode.includes(c.toLowerCase()));
+}
+
 // ===== KULLANICI DOSTU HATA MESAJLARI =====
 
 /** Kargo barkod desteği olmadığında gösterilecek mesajlar */
@@ -72,6 +97,9 @@ export const CARGO_NO_LABEL_MESSAGES = {
 
     /** Trendyol - Desteklenmeyen kargo firması */
     trendyol_no_support: 'Bu kargo firması ortak etiket desteklemiyor. Sadece TEX ve Aras (trendyol öder) destekliyor.',
+
+    /** Çiçeksepeti - Desteklenmeyen kargo firması */
+    ciceksepeti_no_support: 'Bu kargo firması Çiçeksepeti ortak etiket desteği sunmuyor.',
 
     /** Genel mesaj */
     generic: 'Bu kargo firması platform üzerinden barkod desteği sunmuyor.'
@@ -91,6 +119,9 @@ export function getCargoNoLabelMessage(platform: string, isStoreAccount: boolean
     }
     if (platform.toLowerCase().includes('trendyol')) {
         return CARGO_NO_LABEL_MESSAGES.trendyol_no_support;
+    }
+    if (platform.toLowerCase().includes('ciceksepeti') || platform.toLowerCase().includes('çiçeksepeti')) {
+        return CARGO_NO_LABEL_MESSAGES.ciceksepeti_no_support;
     }
     return CARGO_NO_LABEL_MESSAGES.generic;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ export * from './services/response-interpreters/hepsiburada.interpreter';
 export * from './services/response-interpreters/ikas.interpreter';
 export * from './services/response-interpreters/hepsijet.interpreter';
 export * from './services/response-interpreters/tsoft.interpreter';
+export * from './services/response-interpreters/ciceksepeti.interpreter';
 export * from './services/response-interpreters/interpreter.factory';
 
 // Enums

--- a/src/security-logger/SecurityLogger.ts
+++ b/src/security-logger/SecurityLogger.ts
@@ -354,3 +354,4 @@ export const trendyolSecurityLogger = new SecurityLogger('trendyol');
 export const hepsiburadaSecurityLogger = new SecurityLogger('hepsiburada');
 export const ikasSecurityLogger = new SecurityLogger('ikas');
 export const tsoftSecurityLogger = new SecurityLogger('tsoft');
+export const ciceksepetiSecurityLogger = new SecurityLogger('ciceksepeti');

--- a/src/security-logger/index.ts
+++ b/src/security-logger/index.ts
@@ -21,7 +21,8 @@ export {
     trendyolSecurityLogger,
     hepsiburadaSecurityLogger,
     ikasSecurityLogger,
-    tsoftSecurityLogger
+    tsoftSecurityLogger,
+    ciceksepetiSecurityLogger
 } from './SecurityLogger';
 
 export {

--- a/src/services/response-interpreters/ciceksepeti.interpreter.ts
+++ b/src/services/response-interpreters/ciceksepeti.interpreter.ts
@@ -1,0 +1,325 @@
+import { OperationType } from '../../enums/operation-type.enum';
+import { InterpretedResponse } from '../../models/integrationRequestLog.schema';
+import { BaseResponseInterpreter } from './base.interpreter';
+import { logger } from '../logger.service';
+
+/**
+ * Çiçeksepeti API response interpreter
+ *
+ * Çiçeksepeti API'sinin response yapıları:
+ *   - Order/GetOrders → { orderListCount, supplierOrderListWithBranch: [...] }
+ *   - Order/getcanceledorders → { orderItemList: [...] }
+ *   - Order/cancelevaluation → { isSuccess, message }
+ *   - Order/refundprocessstartreceivedprocess → { orderItems: [...] }
+ *   - Products POST/PUT/price-and-stock → { batchId } (async)
+ *   - Products/batch-status/{batchId} → { batchId, itemCount, items: [{status: "Pending|Processing|Success|Failed|Warning"}] }
+ *   - Products GET → { totalCount, products: [...] }
+ *   - Categories GET → { categories: [...] (tree) }
+ *   - Categories/{id}/attributes → { categoryAttributes: [...] }
+ *   - sellerquestions GET → { items: [...], hasNextPage }
+ */
+export class CicekSepetiResponseInterpreter extends BaseResponseInterpreter {
+    interpret(response: any, operationType: OperationType): InterpretedResponse | null {
+        if (this.isEmptyResponse(response)) {
+            return null;
+        }
+
+        try {
+            switch (operationType) {
+                case OperationType.SEND_PRODUCTS:
+                case OperationType.UPDATE_PRODUCTS:
+                case OperationType.UPDATE_STOCK:
+                case OperationType.UPDATE_PRICES:
+                case OperationType.UPDATE_STOCK_AND_PRICE:
+                    return this.interpretBatchSubmit(response, operationType);
+
+                case OperationType.GET_BATCH_STATUS:
+                    return this.interpretBatchStatus(response);
+
+                case OperationType.FETCH_PRODUCTS:
+                    return this.interpretProductList(response);
+
+                case OperationType.FETCH_ORDERS:
+                    return this.interpretOrderOrRefundList(response);
+
+                case OperationType.UPDATE_ORDER:
+                    return this.interpretOrderUpdate(response);
+
+                case OperationType.GET_CATEGORIES:
+                    return this.interpretCategoryList(response);
+
+                case OperationType.GET_CATEGORY_ATTRIBUTES:
+                    return this.interpretCategoryAttributes(response);
+
+                default:
+                    return this.interpretGeneric(response, operationType);
+            }
+        } catch (error) {
+            logger.error('Error interpreting CicekSepeti response', {
+                operationType,
+                error: (error as Error).message
+            });
+            return null;
+        }
+    }
+
+    /**
+     * Batch submit yanıtını yorumla — POST /Products, PUT /Products, PUT /Products/price-and-stock
+     * Response: { batchId: "uuid-..." }
+     */
+    private interpretBatchSubmit(response: any, operationType: OperationType): InterpretedResponse {
+        const batchId = response?.batchId;
+
+        if (batchId) {
+            return {
+                summary: `Batch isteği oluşturuldu (Batch ID: ${batchId})`,
+                success: true,
+                successCount: 0, // gerçek sonuç batch-status üzerinden alınır
+                failureCount: 0,
+                details: {
+                    batchId,
+                    operationType
+                },
+                parsedAt: new Date()
+            };
+        }
+
+        // Hata durumu (Çiçeksepeti 4xx)
+        if (response?.code || response?.message) {
+            return {
+                summary: `Batch isteği başarısız: ${response.message || 'Bilinmeyen hata'}`,
+                success: false,
+                successCount: 0,
+                failureCount: 1,
+                details: {
+                    errorCode: response.code,
+                    errorMessage: response.message,
+                    operationType
+                },
+                parsedAt: new Date()
+            };
+        }
+
+        return this.interpretGeneric(response, operationType);
+    }
+
+    /**
+     * Batch status yanıtını yorumla
+     * Response: { batchId, itemCount, items: [{itemId, status: "Pending|Processing|Success|Failed|Warning", failureReasons}] }
+     */
+    private interpretBatchStatus(response: any): InterpretedResponse {
+        const items = Array.isArray(response?.items) ? response.items : [];
+        const successCount = items.filter((item: any) => item.status === 'Success').length;
+        const failureCount = items.filter((item: any) => item.status === 'Failed').length;
+        const warningCount = items.filter((item: any) => item.status === 'Warning').length;
+        const pendingCount = items.filter(
+            (item: any) => item.status === 'Pending' || item.status === 'Processing'
+        ).length;
+
+        let summary = '';
+        if (pendingCount > 0) {
+            summary = `Batch durumu: ${successCount} başarılı, ${failureCount} başarısız, ${warningCount} uyarılı, ${pendingCount} beklemede`;
+        } else {
+            summary = `Batch tamamlandı: ${successCount} başarılı, ${failureCount} başarısız, ${warningCount} uyarılı`;
+        }
+
+        return {
+            summary,
+            success: failureCount === 0,
+            successCount,
+            failureCount,
+            details: {
+                batchId: response?.batchId,
+                total: response?.itemCount ?? items.length,
+                pending: pendingCount,
+                warning: warningCount,
+                failures: items
+                    .filter((item: any) => item.status === 'Failed')
+                    .map((item: any) => ({
+                        itemId: item.itemId,
+                        failureReasons: item.failureReasons,
+                        data: item.data
+                    }))
+            },
+            parsedAt: new Date()
+        };
+    }
+
+    /**
+     * Ürün listeleme yanıtını yorumla
+     * Response: { totalCount, products: [...] }
+     */
+    private interpretProductList(response: any): InterpretedResponse {
+        const products = Array.isArray(response?.products) ? response.products : [];
+        const totalCount = response?.totalCount ?? products.length;
+
+        return {
+            summary: `${totalCount} ürün getirildi (sayfa: ${products.length})`,
+            success: true,
+            successCount: products.length,
+            details: {
+                totalCount,
+                pageItemCount: products.length
+            },
+            parsedAt: new Date()
+        };
+    }
+
+    /**
+     * Sipariş veya iade listeleme yanıtını yorumla
+     * Order/GetOrders → { orderListCount, supplierOrderListWithBranch: [...] }
+     * Order/getcanceledorders → { orderItemList: [...] }
+     */
+    private interpretOrderOrRefundList(response: any): InterpretedResponse {
+        // Sipariş listesi
+        if (Array.isArray(response?.supplierOrderListWithBranch)) {
+            const items = response.supplierOrderListWithBranch;
+            const totalCount = response.orderListCount ?? items.length;
+            return {
+                summary: `${totalCount} sipariş kaydı getirildi (sayfa: ${items.length})`,
+                success: true,
+                successCount: items.length,
+                details: {
+                    totalCount,
+                    pageItemCount: items.length
+                },
+                parsedAt: new Date()
+            };
+        }
+
+        // İade listesi
+        if (Array.isArray(response?.orderItemList)) {
+            const items = response.orderItemList;
+            return {
+                summary: `${items.length} iade siparişi getirildi`,
+                success: true,
+                successCount: items.length,
+                details: {
+                    pageItemCount: items.length
+                },
+                parsedAt: new Date()
+            };
+        }
+
+        return this.interpretGeneric(response, OperationType.FETCH_ORDERS);
+    }
+
+    /**
+     * Sipariş güncelleme yanıtını yorumla
+     * Order/cancelevaluation → { isSuccess, message }
+     * Order/refundprocessstartreceivedprocess → { orderItems: [{orderItemId, isSuccess, validation}] }
+     */
+    private interpretOrderUpdate(response: any): InterpretedResponse {
+        // cancelevaluation single-result
+        if (typeof response?.isSuccess === 'boolean' && !Array.isArray(response?.orderItems)) {
+            return {
+                summary: response.isSuccess
+                    ? 'Sipariş güncelleme başarılı'
+                    : `Sipariş güncelleme başarısız: ${response.message || 'Bilinmeyen hata'}`,
+                success: response.isSuccess,
+                successCount: response.isSuccess ? 1 : 0,
+                failureCount: response.isSuccess ? 0 : 1,
+                details: {
+                    message: response.message
+                },
+                parsedAt: new Date()
+            };
+        }
+
+        // refundprocess multi-item
+        if (Array.isArray(response?.orderItems)) {
+            const items = response.orderItems;
+            const successCount = items.filter((x: any) => x.isSuccess === true).length;
+            const failureCount = items.filter((x: any) => x.isSuccess === false).length;
+
+            return {
+                summary: `${successCount} item başarılı, ${failureCount} başarısız`,
+                success: failureCount === 0,
+                successCount,
+                failureCount,
+                details: {
+                    items: items.map((x: any) => ({
+                        orderItemId: x.orderItemId,
+                        isSuccess: x.isSuccess,
+                        validation: x.validation
+                    }))
+                },
+                parsedAt: new Date()
+            };
+        }
+
+        return this.interpretGeneric(response, OperationType.UPDATE_ORDER);
+    }
+
+    /**
+     * Kategori listesi yanıtını yorumla (tree yapısı)
+     * Response: { categories: [{id, name, parentCategoryId, subCategories: [...]}] }
+     */
+    private interpretCategoryList(response: any): InterpretedResponse {
+        const categories = Array.isArray(response?.categories) ? response.categories : [];
+
+        // Recursive flat count
+        const countNodes = (nodes: any[]): number => {
+            let total = 0;
+            for (const node of nodes) {
+                total++;
+                if (Array.isArray(node.subCategories)) {
+                    total += countNodes(node.subCategories);
+                }
+            }
+            return total;
+        };
+        const totalNodes = countNodes(categories);
+
+        return {
+            summary: `${totalNodes} kategori (root: ${categories.length})`,
+            success: true,
+            successCount: totalNodes,
+            details: {
+                rootCount: categories.length,
+                totalCount: totalNodes
+            },
+            parsedAt: new Date()
+        };
+    }
+
+    /**
+     * Kategori öznitelik yanıtını yorumla
+     * Response: { categoryId, categoryName, categoryAttributes: [...] }
+     */
+    private interpretCategoryAttributes(response: any): InterpretedResponse {
+        const attributes = Array.isArray(response?.categoryAttributes) ? response.categoryAttributes : [];
+        const requiredCount = attributes.filter((a: any) => a.required === true).length;
+        const variantCount = attributes.filter((a: any) => a.varianter === true).length;
+
+        return {
+            summary: `Kategori için ${attributes.length} özellik getirildi (${requiredCount} zorunlu, ${variantCount} varyant)`,
+            success: true,
+            successCount: attributes.length,
+            details: {
+                categoryId: response?.categoryId,
+                categoryName: response?.categoryName,
+                attributeCount: attributes.length,
+                requiredCount,
+                variantCount
+            },
+            parsedAt: new Date()
+        };
+    }
+
+    /**
+     * Genel yanıt yorumlama
+     */
+    private interpretGeneric(response: any, operationType: OperationType): InterpretedResponse {
+        return {
+            summary: `${operationType} işlemi tamamlandı`,
+            success: true,
+            details: {
+                operationType,
+                responseType: typeof response,
+                hasData: !this.isEmptyResponse(response)
+            },
+            parsedAt: new Date()
+        };
+    }
+}

--- a/src/services/response-interpreters/ciceksepeti.interpreter.ts
+++ b/src/services/response-interpreters/ciceksepeti.interpreter.ts
@@ -51,6 +51,9 @@ export class CicekSepetiResponseInterpreter extends BaseResponseInterpreter {
                 case OperationType.GET_CATEGORY_ATTRIBUTES:
                     return this.interpretCategoryAttributes(response);
 
+                case OperationType.READ:
+                    return this.interpretRead(response, operationType);
+
                 default:
                     return this.interpretGeneric(response, operationType);
             }
@@ -302,6 +305,68 @@ export class CicekSepetiResponseInterpreter extends BaseResponseInterpreter {
                 attributeCount: attributes.length,
                 requiredCount,
                 variantCount
+            },
+            parsedAt: new Date()
+        };
+    }
+
+    /**
+     * READ operation — birden fazla endpoint kullanıyor (sellerquestions, actions vb.)
+     * Response yapısına göre discriminate edilir.
+     */
+    private interpretRead(response: any, operationType: OperationType): InterpretedResponse {
+        // /sellerquestions GET → { items: [...], hasNextPage: boolean }
+        if (Array.isArray(response?.items) && typeof response?.hasNextPage === 'boolean') {
+            return this.interpretQuestionList(response);
+        }
+        // /sellerquestions/actions GET → { actions: [...] } veya array
+        if (Array.isArray(response?.actions) || Array.isArray(response)) {
+            return this.interpretActionsList(response);
+        }
+        return this.interpretGeneric(response, operationType);
+    }
+
+    /**
+     * Soru listesi yanıtını yorumla
+     * Response: { items: [{id, product, question, answer, answered, ...}], hasNextPage: boolean }
+     * Kaynak: docs/integrations/ciceksepeti/pages/019-ürün-sorularını-çekme.md
+     */
+    private interpretQuestionList(response: any): InterpretedResponse {
+        const items = Array.isArray(response?.items) ? response.items : [];
+        const answeredCount = items.filter((q: any) => q.answered === true).length;
+        const unansweredCount = items.filter((q: any) => q.answered === false).length;
+        const hasNextPage = response?.hasNextPage === true;
+
+        return {
+            summary: `${items.length} ürün sorusu getirildi (${answeredCount} cevaplanmış, ${unansweredCount} cevaplanmamış)${hasNextPage ? ' — sonraki sayfa var' : ''}`,
+            success: true,
+            successCount: items.length,
+            details: {
+                pageItemCount: items.length,
+                answeredCount,
+                unansweredCount,
+                hasNextPage
+            },
+            parsedAt: new Date()
+        };
+    }
+
+    /**
+     * BranchAction listesi yanıtını yorumla
+     * Response: { actions: [{name, value, details: [...]}] } veya direkt array
+     * Kaynak: docs/integrations/ciceksepeti/pages/020-ürün-sorularını-cevaplama.md
+     */
+    private interpretActionsList(response: any): InterpretedResponse {
+        const actions = Array.isArray(response?.actions)
+            ? response.actions
+            : (Array.isArray(response) ? response : []);
+
+        return {
+            summary: `${actions.length} branch action getirildi`,
+            success: true,
+            successCount: actions.length,
+            details: {
+                actionCount: actions.length
             },
             parsedAt: new Date()
         };

--- a/src/services/response-interpreters/interpreter.factory.ts
+++ b/src/services/response-interpreters/interpreter.factory.ts
@@ -8,6 +8,7 @@ import { N11ResponseInterpreter } from './n11.interpreter';
 import { IdeaSoftResponseInterpreter } from './ideasoft.interpreter';
 import { HepsiJetResponseInterpreter } from './hepsijet.interpreter';
 import { TSoftResponseInterpreter } from './tsoft.interpreter';
+import { CicekSepetiResponseInterpreter } from './ciceksepeti.interpreter';
 import { logger } from '../logger.service';
 
 /**
@@ -60,6 +61,10 @@ export class ResponseInterpreterFactory {
 
             case ResourceName.TSoft:
                 interpreter = new TSoftResponseInterpreter();
+                break;
+
+            case ResourceName.CicekSepeti:
+                interpreter = new CicekSepetiResponseInterpreter();
                 break;
 
             // Diğer platform'lar için ileride eklenebilir


### PR DESCRIPTION
## Özet

Moon ana repo [issue #557](https://github.com/oguzhanayyldz/moon/issues/557) — Çiçeksepeti marketplace entegrasyonu — için gerekli moon-lib helper'ları.

## Değişiklikler

- **`security-logger/SecurityLogger.ts`** + **`security-logger/index.ts`**: `ciceksepetiSecurityLogger` export edildi (mevcut Trendyol/Hepsiburada/Ikas/N11/T-Soft pattern'inin Çiçeksepeti versiyonu)
- **`common/constants/cargo-label-support.constants.ts`**:
  - `CICEKSEPETI_SUPPORTED_CARGOS: string[]` — şimdilik boş (liste Çiçeksepeti dokümantasyonundan netleşince güncellenecek)
  - `hasCicekSepetiLabelSupport(cargoProviderCode)` — konservatif false döner
  - `CARGO_NO_LABEL_MESSAGES.ciceksepeti_no_support` — kullanıcı dostu mesaj
  - `getCargoNoLabelMessage()` — ciceksepeti platformu için dallanma

## Build

npm run build başarılı — dist/ regenerated.

## Test Etkisi

Bu eklemeler mevcut hiçbir export'u değiştirmiyor; backward-compatible.

## İlgili Moon PR

Ana repo PR'ı bu PR ile birlikte açılacaktır.

---
*Bu PR /work 557 komutu ile oluşturulmustur.*